### PR TITLE
Adapt button appearance to Figma sketch, fix color scheme

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/components/overrides/Button.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/components/overrides/Button.kt
@@ -1,11 +1,14 @@
 package com.github.familyvault.components.overrides
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
 import androidx.compose.material.Button as MaterialButton
 
 @Composable
@@ -13,14 +16,16 @@ fun Button(
     content: String,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    shape: Shape = RoundedCornerShape(8.dp),
     containerColor: Color = MaterialTheme.colorScheme.primary,
-    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    contentColor: Color = MaterialTheme.colorScheme.onPrimary,
     onClick: () -> Unit
 ) {
     MaterialButton(
         onClick = onClick,
         modifier = modifier,
         enabled = enabled,
+        shape = shape,
         colors = ButtonDefaults.buttonColors(
             backgroundColor = containerColor,
             contentColor = contentColor

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/screens/FamilyGroupCreateScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/screens/FamilyGroupCreateScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.runtime.Composable
@@ -25,6 +24,7 @@ import com.github.familyvault.components.TextField
 import com.github.familyvault.components.dialogs.FamilyGroupCreatingDialog
 import com.github.familyvault.components.screen.StartScreen
 import com.github.familyvault.components.typography.Headline1
+import com.github.familyvault.components.typography.Paragraph
 import com.github.familyvault.services.IFamilyGroupManagerService
 import com.github.familyvault.ui.theme.AdditionalTheme
 import familyvault.composeapp.generated.resources.Res
@@ -62,19 +62,19 @@ class FamilyGroupCreateScreen : Screen {
             TextField(
                 modifier = Modifier.fillMaxWidth(),
                 value = firstname,
-                label = { Text(stringResource(Res.string.text_field_name_label)) },
+                label = { Paragraph(stringResource(Res.string.text_field_name_label)) },
                 onValueChange = { firstname = it },
             )
             TextField(
                 modifier = Modifier.fillMaxWidth(),
                 value = surname,
-                label = { Text(stringResource(Res.string.text_field_surname_label)) },
+                label = { Paragraph(stringResource(Res.string.text_field_surname_label)) },
                 onValueChange = { surname = it },
             )
             TextField(
                 modifier = Modifier.fillMaxWidth(),
                 value = familyGroupName,
-                label = { Text(stringResource(Res.string.text_field_group_name_label)) },
+                label = { Paragraph(stringResource(Res.string.text_field_group_name_label)) },
                 enabled = !isCreatingFamilyGroup,
                 onValueChange = { familyGroupName = it },
             )

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/theme/Color.kt
@@ -2,7 +2,7 @@ package com.github.familyvault.ui.theme
 import androidx.compose.ui.graphics.Color
 
 val primaryLight = Color(0xFF368dff)
-val onPrimaryLight = Color(0xFF368DFF)
+val onPrimaryLight = Color(0xFFFFFFFF)
 val primaryContainerLight = Color(0xFFD6E3FF)
 val onPrimaryContainerLight = Color(0xFF274777)
 val secondaryLight = Color(0xFF3C6090)
@@ -12,7 +12,7 @@ val onSecondaryContainerLight = Color(0xFF214876)
 
 
 val primaryDark = Color(0xFF368dff)
-val onPrimaryDark = Color(0xFF328dfc)
+val onPrimaryDark = Color(0xFFFFFFFF)
 val primaryContainerDark = Color(0xFF274777)
 val onPrimaryContainerDark = Color(0xFF8ca9df)
 val secondaryDark = Color(0xFFA5C8FF)


### PR DESCRIPTION
Dopasowałem wygląd przycisku "Dalej" do tego, który zaprojektowaliśmy na naszej Figmie. Ponadto przy tym zauważyłem pewien problem przy kolorach w naszym motywie - "primary" był identyczny z "onPrimary", zostało to poprawione dzięki czemu przycisk wygląda tak jak powinien.