### PR TITLE
Add CustomIcon in PrivateKeyAssignPasswordScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/screens/initial/PrivateKeyAssignPasswordScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/screens/initial/PrivateKeyAssignPasswordScreen.kt
@@ -2,10 +2,14 @@ package com.github.familyvault.screens.initial
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Key
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,6 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.github.familyvault.components.CustomIcon
 import com.github.familyvault.components.InfoBox
 import com.github.familyvault.components.InitialScreenButton
 import com.github.familyvault.components.ValidationErrorMessage
@@ -55,6 +60,10 @@ class PrivateKeyAssignPasswordScreen(private val familyGroupDraft: FamilyGroupCr
                 FamilyGroupCreatingDialog()
             }
             PrivateKeyAssignPasswordHeader()
+            CustomIcon(
+                icon = Icons.Outlined.Key
+            )
+            Spacer(modifier = Modifier.height(AdditionalTheme.spacings.large))
             InfoBox(
                 title = stringResource(Res.string.private_key_about_title),
                 content = stringResource(Res.string.private_key_about_content)


### PR DESCRIPTION
Dodałem ikonkę klucza na ekranie PrivateKeyAssignPasswordScreen, która sprawi, że ten ekran będzie trochę przyjaźniejszy dla oka użytkownika.
![image](https://github.com/user-attachments/assets/6f1c894a-863a-440e-a50d-32e6ab365fdc)
