### PR TITLE
Fix permission display for specific user

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-en/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-en/strings.xml
@@ -151,6 +151,8 @@
     <string name="user_modification_choose_permission_content">Select this user's permission group.</string>
     <string name="user_modification_remove_user_button_content">Remove this user</string>
     <string name="user_modification_save_button">Save changes</string>
+    <string name="user_modification_no_permission">Only guardians can change member roles.</string>
+    <string name="user_modification_last_guardian_error">You are the last Guardian in the group. At least one Guardian must remain.</string>
 
     <!-- Select family group -->
     <string name="select_family_group_description">Select a family group to join, or create a new one using the button at the bottom of the screen.</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -151,6 +151,8 @@
     <string name="user_modification_choose_permission_content">Wybierz rolę tego użytkownika.</string>
     <string name="user_modification_remove_user_button_content">Usuń tego użytkownika</string>
     <string name="user_modification_save_button">Zapisz zmiany</string>
+    <string name="user_modification_no_permission">Tylko opiekunowie mogą zmieniać role członków grupy rodzinnej.</string>
+    <string name="user_modification_last_guardian_error">Jesteś ostatnim Opiekunem w grupie. W grupie musi pozostać co najmniej jeden Opiekun.</string>
 
     <!-- Select family group -->
     <string name="select_family_group_description">Wybierz grupę rodzinną, do której chcesz dołączyć. Możesz też utworzyć nową, korzystając z przycisku na dole ekranu.</string>

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/components/FamilyMemberEntry.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/components/FamilyMemberEntry.kt
@@ -1,20 +1,24 @@
 package com.github.familyvault.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.github.familyvault.models.FamilyMember
 import com.github.familyvault.ui.components.typography.Paragraph
+import com.github.familyvault.ui.components.typography.ParagraphMuted
 import com.github.familyvault.ui.theme.AdditionalTheme
 import com.github.familyvault.utils.TextShortener
 
 @Composable
 fun FamilyMemberEntry(
     familyMember: FamilyMember,
+    additionalDescription: String? = null,
     actionComponent: @Composable () -> Unit
 ) {
     Row(
@@ -28,7 +32,17 @@ fun FamilyMemberEntry(
             horizontalArrangement = Arrangement.spacedBy(AdditionalTheme.spacings.medium),
         ) {
             UserAvatar(firstName = familyMember.firstname)
-            Paragraph(TextShortener.shortenText(familyMember.fullname, 30))
+            if (additionalDescription != null) {
+                Column {
+                    Paragraph(TextShortener.shortenText(familyMember.fullname, 30))
+                    ParagraphMuted(
+                        text = additionalDescription,
+                        modifier = Modifier.padding(top = AdditionalTheme.spacings.small)
+                    )
+                }
+            } else {
+                Paragraph(TextShortener.shortenText(familyMember.fullname, 30))
+            }
         }
         actionComponent()
     }

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/components/FamilyMemberEntry.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/components/FamilyMemberEntry.kt
@@ -32,16 +32,14 @@ fun FamilyMemberEntry(
             horizontalArrangement = Arrangement.spacedBy(AdditionalTheme.spacings.medium),
         ) {
             UserAvatar(firstName = familyMember.firstname)
-            if (additionalDescription != null) {
-                Column {
-                    Paragraph(TextShortener.shortenText(familyMember.fullname, 30))
+            Column {
+                Paragraph(TextShortener.shortenText(familyMember.fullname, 30))
+                additionalDescription?.let {
                     ParagraphMuted(
                         text = additionalDescription,
                         modifier = Modifier.padding(top = AdditionalTheme.spacings.small)
                     )
                 }
-            } else {
-                Paragraph(TextShortener.shortenText(familyMember.fullname, 30))
             }
         }
         actionComponent()

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/FamilyGroupSettingMembersScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/FamilyGroupSettingMembersScreen.kt
@@ -3,8 +3,6 @@ package com.github.familyvault.ui.screens.main.familyGroupSettings
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -32,16 +30,12 @@ import com.github.familyvault.models.enums.FamilyGroupMemberPermissionGroup
 import com.github.familyvault.services.IFamilyGroupService
 import com.github.familyvault.ui.components.ContentWithAction
 import com.github.familyvault.ui.components.FamilyMemberEntry
-import com.github.familyvault.ui.components.UserAvatar
 import com.github.familyvault.ui.components.overrides.Button
 import com.github.familyvault.ui.components.overrides.TopAppBar
 import com.github.familyvault.ui.components.settings.DescriptionSection
-import com.github.familyvault.ui.components.typography.Paragraph
-import com.github.familyvault.ui.components.typography.ParagraphMuted
 import com.github.familyvault.ui.screens.main.familyGroupSettings.familyGroupMember.AddMemberToFamilyGroupScreen
 import com.github.familyvault.ui.screens.main.familyGroupSettings.familyGroupMember.ModifyFamilyMemberScreen
 import com.github.familyvault.ui.theme.AdditionalTheme
-import com.github.familyvault.utils.TextShortener
 import familyvault.composeapp.generated.resources.Res
 import familyvault.composeapp.generated.resources.family_group_add_new_member
 import familyvault.composeapp.generated.resources.setting_members_long

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/FamilyGroupSettingMembersScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/FamilyGroupSettingMembersScreen.kt
@@ -31,6 +31,7 @@ import com.github.familyvault.models.FamilyMember
 import com.github.familyvault.models.enums.FamilyGroupMemberPermissionGroup
 import com.github.familyvault.services.IFamilyGroupService
 import com.github.familyvault.ui.components.ContentWithAction
+import com.github.familyvault.ui.components.FamilyMemberEntry
 import com.github.familyvault.ui.components.UserAvatar
 import com.github.familyvault.ui.components.overrides.Button
 import com.github.familyvault.ui.components.overrides.TopAppBar
@@ -103,13 +104,19 @@ class FamilyGroupSettingMembersScreen : Screen {
                             }
                         } else {
                             familyGroupMembers.forEach { member ->
-                                FamilyMemberEntryWithPermission(
+                                FamilyMemberEntry(
                                     familyMember = member,
-                                    permissionGroupText = getPermissionGroupString(member.permissionGroup),
-                                    onActionClick = {
+                                    additionalDescription = getPermissionGroupString(member.permissionGroup)
+                                ) {
+                                    IconButton(onClick = {
                                         navigator.push(ModifyFamilyMemberScreen(member))
+                                    }) {
+                                        Icon(
+                                            Icons.Outlined.MoreHoriz,
+                                            contentDescription = stringResource(Res.string.user_modification_description),
+                                        )
                                     }
-                                )
+                                }
                             }
                         }
                     }
@@ -118,40 +125,6 @@ class FamilyGroupSettingMembersScreen : Screen {
                     AddFamilyMemberButton()
                 }
             )
-        }
-    }
-
-    @Composable
-    private fun FamilyMemberEntryWithPermission(
-        familyMember: FamilyMember,
-        permissionGroupText: String,
-        onActionClick: () -> Unit
-    ) {
-        Row(
-            modifier = Modifier.defaultMinSize(minHeight = AdditionalTheme.sizing.entryMinSize)
-                .fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(AdditionalTheme.spacings.medium),
-            ) {
-                UserAvatar(firstName = familyMember.firstname)
-                Column {
-                    Paragraph(TextShortener.shortenText(familyMember.fullname, 30))
-                    ParagraphMuted(
-                        text = permissionGroupText,
-                        modifier = Modifier.padding(top = AdditionalTheme.spacings.small)
-                    )
-                }
-            }
-            IconButton(onClick = onActionClick) {
-                Icon(
-                    Icons.Outlined.MoreHoriz,
-                    contentDescription = stringResource(Res.string.user_modification_description),
-                )
-            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/familyGroupMember/ModifyFamilyMemberScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/familyGroupMember/ModifyFamilyMemberScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/familyGroupMember/ModifyFamilyMemberScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/familyGroupMember/ModifyFamilyMemberScreen.kt
@@ -72,7 +72,7 @@ class ModifyFamilyMemberScreen(private val familyMember: FamilyMember) : Screen 
 
         val coroutineScope = rememberCoroutineScope()
 
-        DisposableEffect(Unit) {
+        LaunchedEffect(Unit) {
             coroutineScope.launch {
                 allFamilyMembers = familyGroupService.retrieveFamilyGroupMembersList()
                 val myMemberData = familyGroupService.retrieveMyFamilyMemberData()
@@ -86,8 +86,7 @@ class ModifyFamilyMemberScreen(private val familyMember: FamilyMember) : Screen 
                 
                 isLoading = false
             }
-            onDispose { }
-        }
+            }
 
         val options = listOf(
             PermissionOption(

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/familyGroupMember/ModifyFamilyMemberScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/familyGroupMember/ModifyFamilyMemberScreen.kt
@@ -78,7 +78,7 @@ class ModifyFamilyMemberScreen(private val familyMember: FamilyMember) : Screen 
         )
         var savingChanges by remember { mutableStateOf(false) }
         var showDialog by remember { mutableStateOf(false) }
-        var selectedPermissionGroup by remember { mutableStateOf(FamilyGroupMemberPermissionGroup.Guest) }
+        var selectedPermissionGroup by remember { mutableStateOf(familyMember.permissionGroup) }
         val coroutineScope = rememberCoroutineScope()
 
         Scaffold(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ffcef4d1-da80-4b40-9d8d-626da65e0ce9)
Domyslnie wyświetla się zaznaczona prawdziwa grupa uprawnień użytkownika, a nie Guest.

Dodałem nazwy grup permisji pod imionami członków
![image](https://github.com/user-attachments/assets/ed322d9e-f828-4d7a-86b5-6c36c1a48d5b)

Ostatni opiekun w grupie nie może zabrać sobie tych permisji
![image](https://github.com/user-attachments/assets/d736e6db-b491-4613-b658-448e6b4a8d7f)

Tylko opiekun może edytować grupy permisji
![image](https://github.com/user-attachments/assets/c1187ece-52bc-42f9-9503-97b20f367f57)
