### PR TITLE
Fix permissions check in family group settings and task list row

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-en/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-en/strings.xml
@@ -103,6 +103,7 @@
     <string name="family_group_members">Family group members</string>
     <string name="family_group_add_new_member">Add new member</string>
     <string name="family_group_delete_member">Remove member</string>
+    <string name="setting_no_permission">You don't have permission to do that.</string>
 
     <!-- Add member to family group-->
     <string name="add_member_to_family_group_header">Add new member</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -103,6 +103,7 @@
     <string name="family_group_members">Członkowie grupy rodzinnej</string>
     <string name="family_group_add_new_member">Dodaj nowego członka</string>
     <string name="family_group_delete_member">Usuń członka</string>
+    <string name="setting_no_permission">Nie masz uprawnień, aby tutaj wejść.</string>
 
     <!-- Add member to family group-->
     <string name="add_member_to_family_group_header">Dodaj nowego członka</string>

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/forms/FamilyGroupMemberForm.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/forms/FamilyGroupMemberForm.kt
@@ -38,12 +38,12 @@ class FamilyGroupMemberForm : BaseForm() {
     override fun validateForm() {
         formData.firstname.validationError = FormValidator.multipleValidators(
             FormValidator.validateEmpty(firstname),
-            FormValidator.validateTooLong(firstname),
+            FormValidator.validateTooLong(firstname, maxLength = 25),
         )
 
         formData.surname.validationError = FormValidator.multipleValidators(
             FormValidator.validateEmpty(surname),
-            FormValidator.validateTooLong(surname),
+            FormValidator.validateTooLong(surname, maxLength = 25),
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/FamilyGroupSettingMembersScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/FamilyGroupSettingMembersScreen.kt
@@ -64,12 +64,13 @@ class FamilyGroupSettingMembersScreen : Screen {
         val navigator = LocalNavigator.currentOrThrow
         val familyGroupService = koinInject<IFamilyGroupService>()
         val familyGroupMembers = remember { mutableStateListOf<FamilyMember>() }
-
+        var currentFamilyGroupMemberPermissionGroup by remember { mutableStateOf(FamilyGroupMemberPermissionGroup.Guest)}
         var isLoadingMembers by remember { mutableStateOf(true) }
 
         LaunchedEffect(Unit) {
             isLoadingMembers = true
             familyGroupMembers.addAll(familyGroupService.retrieveFamilyGroupMembersList())
+            currentFamilyGroupMemberPermissionGroup = familyGroupService.retrieveMyFamilyMemberData().permissionGroup
             isLoadingMembers = false
         }
 
@@ -117,20 +118,21 @@ class FamilyGroupSettingMembersScreen : Screen {
                     }
                 },
                 actionButton = {
-                    AddFamilyMemberButton()
+                    AddFamilyMemberButton(currentFamilyGroupMemberPermissionGroup)
                 }
             )
         }
     }
 
     @Composable
-    private fun AddFamilyMemberButton() {
+    private fun AddFamilyMemberButton(currentUserPermissionGroup: FamilyGroupMemberPermissionGroup) {
         val navigator = LocalNavigator.currentOrThrow
 
         Button(
             text = stringResource(Res.string.family_group_add_new_member),
             icon = Icons.Filled.Add,
             modifier = Modifier.fillMaxWidth(),
+            enabled = currentUserPermissionGroup == FamilyGroupMemberPermissionGroup.Guardian,
             onClick = {
                 navigator.push(AddMemberToFamilyGroupScreen())
             })

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/FamilyGroupSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/familyGroupSettings/FamilyGroupSettingsScreen.kt
@@ -1,6 +1,8 @@
 package com.github.familyvault.ui.screens.main.familyGroupSettings
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
@@ -8,12 +10,25 @@ import androidx.compose.material.icons.outlined.GroupAdd
 import androidx.compose.material.icons.outlined.Groups
 import androidx.compose.material.icons.outlined.PersonAdd
 import androidx.compose.material.icons.outlined.SwapHoriz
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.github.familyvault.models.enums.FamilyGroupMemberPermissionGroup
+import com.github.familyvault.services.IFamilyGroupService
 import com.github.familyvault.ui.components.SettingsCategory
 import com.github.familyvault.ui.components.overrides.TopAppBar
 import com.github.familyvault.ui.components.settings.SettingItem
@@ -22,6 +37,8 @@ import com.github.familyvault.ui.screens.main.familyGroupSettings.familyGroupMem
 import com.github.familyvault.ui.screens.start.StartScreen
 import com.github.familyvault.ui.theme.AdditionalTheme
 import familyvault.composeapp.generated.resources.Res
+import familyvault.composeapp.generated.resources.setting_no_permission
+import familyvault.composeapp.generated.resources.confirm_button_content
 import familyvault.composeapp.generated.resources.setting_add_member_short
 import familyvault.composeapp.generated.resources.setting_add_member_title
 import familyvault.composeapp.generated.resources.setting_change_family_group_short
@@ -35,12 +52,26 @@ import familyvault.composeapp.generated.resources.setting_members_title
 import familyvault.composeapp.generated.resources.settings_category_management
 import familyvault.composeapp.generated.resources.settings_category_other_family_groups
 import familyvault.composeapp.generated.resources.settings_title
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
 class FamilyGroupSettingsScreen : Screen {
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
+        val familyGroupService = koinInject<IFamilyGroupService>()
+        var isLoadingPermissionGroup by remember { mutableStateOf(true) }
+        var showPermissionErrorDialog by remember { mutableStateOf(false) }
+        var currentUserPermissionGroup by remember { mutableStateOf(FamilyGroupMemberPermissionGroup.Guest) }
+        val coroutineScope = rememberCoroutineScope()
+
+        LaunchedEffect(Unit) {
+            isLoadingPermissionGroup = true
+            currentUserPermissionGroup =
+                familyGroupService.retrieveMyFamilyMemberData().permissionGroup
+            isLoadingPermissionGroup = false
+        }
 
         Scaffold(
             topBar = {
@@ -49,50 +80,90 @@ class FamilyGroupSettingsScreen : Screen {
                 )
             },
         ) { paddingValues ->
-            Column(
-                modifier = Modifier.padding(paddingValues)
-                    .padding(vertical = AdditionalTheme.spacings.screenPadding)
-            ) {
-                SettingsCategory(stringResource(Res.string.settings_category_other_family_groups)) {
-                    SettingItem(
-                        Icons.Outlined.GroupAdd,
-                        title = stringResource(Res.string.setting_join_or_create_family_group_title),
-                        description = stringResource(Res.string.setting_join_or_create_family_group_short),
-                        onClick = {
-                            navigator.push(StartScreen())
-                        })
-                    SettingItem(
-                        Icons.Outlined.SwapHoriz,
-                        title = stringResource(Res.string.setting_change_family_group_title),
-                        description = stringResource(Res.string.setting_change_family_group_short),
-                        onClick = {
-                            navigator.push(ChangeFamilyGroupScreen())
-                        })
+            if (!isLoadingPermissionGroup) {
+                Column(
+                    modifier = Modifier.padding(paddingValues)
+                        .padding(vertical = AdditionalTheme.spacings.screenPadding)
+                ) {
+                    SettingsCategory(stringResource(Res.string.settings_category_other_family_groups)) {
+                        SettingItem(
+                            Icons.Outlined.GroupAdd,
+                            title = stringResource(Res.string.setting_join_or_create_family_group_title),
+                            description = stringResource(Res.string.setting_join_or_create_family_group_short),
+                            onClick = {
+                                navigator.push(StartScreen())
+                            })
+                        SettingItem(
+                            Icons.Outlined.SwapHoriz,
+                            title = stringResource(Res.string.setting_change_family_group_title),
+                            description = stringResource(Res.string.setting_change_family_group_short),
+                            onClick = {
+                                navigator.push(ChangeFamilyGroupScreen())
+                            })
+                    }
+                    SettingsCategory(stringResource(Res.string.settings_category_management)) {
+                        if (currentUserPermissionGroup == FamilyGroupMemberPermissionGroup.Guardian) {
+                            SettingItem(
+                                Icons.Outlined.Edit,
+                                title = stringResource(Res.string.setting_change_name_title),
+                                description = stringResource(Res.string.setting_change_name_description_short),
+                                onClick = {
+                                    coroutineScope.launch {
+                                        currentUserPermissionGroup = familyGroupService.retrieveMyFamilyMemberData().permissionGroup
+                                        if (currentUserPermissionGroup == FamilyGroupMemberPermissionGroup.Guardian) {
+                                            navigator.push(FamilyGroupSettingChangeNameScreen())
+                                        } else {
+                                            showPermissionErrorDialog = true
+                                        }
+                                    }
+                                })
+                        }
+                        if (currentUserPermissionGroup == FamilyGroupMemberPermissionGroup.Guardian) {
+                            SettingItem(
+                                Icons.Outlined.PersonAdd,
+                                title = stringResource(Res.string.setting_add_member_title),
+                                description = stringResource(Res.string.setting_add_member_short),
+                                onClick = {
+                                    coroutineScope.launch {
+                                        currentUserPermissionGroup = familyGroupService.retrieveMyFamilyMemberData().permissionGroup
+                                        if (currentUserPermissionGroup == FamilyGroupMemberPermissionGroup.Guardian) {
+                                            navigator.push(AddMemberToFamilyGroupScreen())
+                                        } else {
+                                            showPermissionErrorDialog = true
+                                        }
+                                    }
+                                })
+                        }
+                        SettingItem(
+                            Icons.Outlined.Groups,
+                            title = stringResource(Res.string.setting_members_title),
+                            description = stringResource(Res.string.setting_members_short),
+                            onClick = {
+                                navigator.push(FamilyGroupSettingMembersScreen())
+                            })
+                    }
                 }
-                SettingsCategory(stringResource(Res.string.settings_category_management)) {
-                    SettingItem(
-                        Icons.Outlined.Edit,
-                        title = stringResource(Res.string.setting_change_name_title),
-                        description = stringResource(Res.string.setting_change_name_description_short),
-                        onClick = {
-                            navigator.push(FamilyGroupSettingChangeNameScreen())
-                        })
-                    SettingItem(
-                        Icons.Outlined.PersonAdd,
-                        title = stringResource(Res.string.setting_add_member_title),
-                        description = stringResource(Res.string.setting_add_member_short),
-                        onClick = {
-                            navigator.push(AddMemberToFamilyGroupScreen())
-                        })
-                    SettingItem(
-                        Icons.Outlined.Groups,
-                        title = stringResource(Res.string.setting_members_title),
-                        description = stringResource(Res.string.setting_members_short),
-                        onClick = {
-                            navigator.push(FamilyGroupSettingMembersScreen())
-                        })
+            } else {
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
                 }
+            }
+
+            if (showPermissionErrorDialog) {
+                AlertDialog(
+                    onDismissRequest = { showPermissionErrorDialog = false },
+                    text = { Text(stringResource(Res.string.setting_no_permission)) },
+                    confirmButton = {
+                        TextButton(onClick = { showPermissionErrorDialog = false }) {
+                            Text(stringResource(Res.string.confirm_button_content))
+                        }
+                    },
+                )
             }
         }
     }
+
 }

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListContent.kt
@@ -22,7 +22,6 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import com.github.familyvault.models.enums.FamilyGroupMemberPermissionGroup
 import com.github.familyvault.services.IFamilyGroupService
 import com.github.familyvault.services.listeners.ITaskListenerService
-import com.github.familyvault.services.listeners.ITaskListListenerService
 import com.github.familyvault.states.ITaskListState
 import com.github.familyvault.ui.components.HorizontalScrollableRow
 import com.github.familyvault.ui.components.tasks.TaskGroupCompleted

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListContent.kt
@@ -11,10 +11,16 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import com.github.familyvault.models.enums.FamilyGroupMemberPermissionGroup
+import com.github.familyvault.services.IFamilyGroupService
 import com.github.familyvault.services.listeners.ITaskListenerService
 import com.github.familyvault.services.listeners.ITaskListListenerService
 import com.github.familyvault.states.ITaskListState
@@ -30,9 +36,10 @@ import org.koin.compose.koinInject
 @Composable
 fun TaskListContent() {
     val localNavigator = LocalNavigator.currentOrThrow
+    val familyGroupService = koinInject<IFamilyGroupService>()
     val taskListState = koinInject<ITaskListState>()
     val taskListenerService = koinInject<ITaskListenerService>()
-
+    var currentUserPermissionGroup by remember { mutableStateOf(FamilyGroupMemberPermissionGroup.Guest)}
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
 
@@ -47,6 +54,7 @@ fun TaskListContent() {
                 taskListState.updateTask(it)
             }
         }
+        currentUserPermissionGroup = familyGroupService.retrieveMyFamilyMemberData().permissionGroup
     }
 
     LaunchedEffect(taskListState.taskLists) {
@@ -79,8 +87,10 @@ fun TaskListContent() {
                     }
                 }
             }
-            TaskNewListButton {
-                localNavigator.parent?.push(TaskNewListScreen())
+            if (currentUserPermissionGroup == FamilyGroupMemberPermissionGroup.Guardian) {
+                TaskNewListButton {
+                    localNavigator.parent?.push(TaskNewListScreen())
+                }
             }
         }
 


### PR DESCRIPTION
Mały komentarz do maksymalnej długości nazwy użytkownika:
za `https://bridge.privmx.dev/#context-addusertocontext` - długość `user-id` ma znajdować się w przedziale [1;128]. Przy naszym obecnym formacie zapisu nazwy użytkownika daje nam to 55 znaków używalnych dla użytkownika - zatem jeśli dzielimy po równo 55 to wychodzi nam po 27.5 znaku na imię i tyle samo na nazwisko. Dałem zatem max. po 25 znaków na każde z tych dwóch pól. Alternatywnie możemy weryfikować, czy łącznie mają max. 55 znaków.

fixes #124 
fixes #123 
fixes #122 