### PR TITLE
Task list fixes

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/services/ITaskService.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/services/ITaskService.kt
@@ -7,7 +7,7 @@ import com.github.familyvault.models.tasks.TaskList
 interface ITaskService {
     suspend fun getTaskLists(): List<TaskList>
     suspend fun createNewTaskList(name: String)
-    suspend fun updateTaskList(taskListId: String, name: String)
+    suspend fun updateTaskList(taskListId: String, name: String): Boolean
     suspend fun deleteTaskList(taskListId: String)
 
     suspend fun createNewTask(

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/services/TaskService.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/services/TaskService.kt
@@ -37,17 +37,22 @@ class TaskService(
         )
     }
 
-    override suspend fun updateTaskList(taskListId: String, name: String) {
-        val splitFamilyMembers = FamilyMembersSplitter.split(
-            familyGroupService.retrieveFamilyGroupMembersList()
-        )
+    override suspend fun updateTaskList(taskListId: String, name: String): Boolean {
+        return try {
+            val splitFamilyMembers = FamilyMembersSplitter.split(
+                familyGroupService.retrieveFamilyGroupMembersList()
+            )
 
-        privMxClient.updateThread(
-            taskListId,
-            users = splitFamilyMembers.members.map { it.toPrivMxUser() },
-            managers = splitFamilyMembers.guardians.map { it.toPrivMxUser() },
-            newName = name,
-        )
+            privMxClient.updateThread(
+                taskListId,
+                users = splitFamilyMembers.members.map { it.toPrivMxUser() },
+                managers = splitFamilyMembers.guardians.map { it.toPrivMxUser() },
+                newName = name,
+            )
+            true
+        } catch (e: Exception) {
+            false
+        }
     }
 
     override suspend fun deleteTaskList(taskListId: String) {

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/TaskTabContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/TaskTabContent.kt
@@ -39,19 +39,29 @@ fun TaskTabContent() {
         tasksCategoriesState.populateTaskListFromServices()
         familyMembersState.populateFamilyGroupMembersFromService()
 
-        taskListListenerService.startListeningForNewTaskList { newList ->
-            tasksListState.taskLists.add(newList)
-        }
-        taskListListenerService.startListeningForUpdatedTaskList { updatedList ->
-            tasksListState.updateTaskList(updatedList)
+        try {
+            taskListListenerService.startListeningForNewTaskList { newList ->
+                tasksListState.taskLists.add(newList)
+            }
+        } catch (_: Exception) {
         }
 
-        taskListListenerService.startListeningForDeletedTaskList { deletedListId ->
-            coroutineScope.launch {
-                isLoading = true
-                tasksListState.removeTaskList(deletedListId.threadId)
-                isLoading = false
+        try {
+            taskListListenerService.startListeningForUpdatedTaskList { updatedList ->
+                tasksListState.updateTaskList(updatedList)
             }
+        } catch (_: Exception) {
+        }
+
+        try {
+            taskListListenerService.startListeningForDeletedTaskList { deletedListId ->
+                coroutineScope.launch {
+                    isLoading = true
+                    tasksListState.removeTaskList(deletedListId.threadId)
+                    isLoading = false
+                }
+            }
+        } catch (_: Exception) {
         }
 
         isLoading = false

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListContent.kt
@@ -106,11 +106,12 @@ fun TaskListContent() {
                 .verticalScroll(scrollState)
         ) {
             taskListState.selectedTaskList?.let { taskList ->
+                val currentTaskList = taskListState.taskLists.find { it.id == taskList.id } ?: taskList
                 TaskGroupPending(
-                    categoryTitle = taskList.name,
+                    categoryTitle = currentTaskList.name,
                     tasks = taskListState.tasks.filter { !it.content.completed },
                     onEditClick = {
-                        localNavigator.parent?.push(TaskListEditScreen(taskList))
+                        localNavigator.parent?.push(TaskListEditScreen(currentTaskList))
                     },
                     permissionGroup = currentUserPermissionGroup
                 )

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListContent.kt
@@ -83,7 +83,7 @@ fun TaskListContent() {
             taskListState.taskLists.forEach {
                 TaskListButton(
                     title = it.name,
-                    selected = it == taskListState.selectedTaskList
+                    selected = it.id == taskListState.selectedTaskList?.id
                 ) {
                     coroutineScope.launch {
                         taskListState.selectTaskList(it.id)

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListEditScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/screens/main/tasks/taskList/TaskListEditScreen.kt
@@ -83,13 +83,18 @@ class TaskListEditScreen(private val taskList: TaskList) : Screen {
                             ) {
                                 coroutineScope.launch {
                                     isEditing = true
-                                    taskService.updateTaskList(taskList.id, taskListForm.name)
-                                    taskListState.populateTaskListFromServices()
-                                    if (taskList.id == taskListState.selectedTaskList?.id) {
-                                        taskListState.selectTaskList(taskList.id)
+                                    val updateResult = taskService.updateTaskList(taskList.id, taskListForm.name)
+                                    
+                                    if (updateResult) {
+                                        taskListState.populateTaskListFromServices()
+                                        if (taskList.id == taskListState.selectedTaskList?.id) {
+                                            taskListState.selectTaskList(taskList.id)
+                                        }
+                                        isEditing = false
+                                        localNavigator.pop()
+                                    } else {
+                                        isEditing = false
                                     }
-                                    isEditing = false
-                                    localNavigator.pop()
                                 }
                             }
                             DangerButton(


### PR DESCRIPTION
fix #162, fix #167 
dodatkowo naprawia wyświetlanie nazwy listy zadań w przypadku jej zmiany (przycisk na HorizontalScrollableRow jest dalej selected po zmianie, TaskGroupPending poprawnie aktualizuje nazwę)