### PR TITLE
Fix sender name and timestamp

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/utils/ChatMessageAdditionalInfoClassifier.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/utils/ChatMessageAdditionalInfoClassifier.kt
@@ -9,36 +9,36 @@ object ChatMessageAdditionalInfoClassifier : IChatMessageAdditionalInfoClassifie
         prevMessage: ChatMessage?,
         nextMessage: ChatMessage?
     ): ChatMessageAdditionalInfo {
-        if (prevMessage == null) {
-            if (nextMessage != null && senderIsDifferent(message, nextMessage)) {
-                return ChatMessageAdditionalInfo.FULL
-            }
-            return ChatMessageAdditionalInfo.SEND_DATE
-        }
-
         if (nextMessage == null) {
-            if (senderIsDifferent(prevMessage, message)) {
+            if (prevMessage != null && senderIsDifferent(message, prevMessage)) {
                 return ChatMessageAdditionalInfo.FULL
             }
             return ChatMessageAdditionalInfo.SENDER_NAME
         }
 
+        if (prevMessage == null) {
+            if (senderIsDifferent(nextMessage, message)) {
+                return ChatMessageAdditionalInfo.FULL
+            }
+            return ChatMessageAdditionalInfo.SEND_DATE
+        }
+
         if (
-            senderIsDifferent(prevMessage, message) &&
-            senderIsDifferent(message, nextMessage)
+            senderIsDifferent(nextMessage, message) &&
+            senderIsDifferent(message, prevMessage)
         ) {
             return ChatMessageAdditionalInfo.FULL
         }
 
-        if (senderIsDifferent(prevMessage, message) && !senderIsDifferent(message, nextMessage)) {
-            return ChatMessageAdditionalInfo.SEND_DATE
-        }
-
-        if (!senderIsDifferent(prevMessage, message) && senderIsDifferent(message, nextMessage)) {
+        if (senderIsDifferent(nextMessage, message) && !senderIsDifferent(message, prevMessage)) {
             return ChatMessageAdditionalInfo.SENDER_NAME
         }
 
-        if (!senderIsDifferent(prevMessage, message) && !senderIsDifferent(message, nextMessage)) {
+        if (!senderIsDifferent(nextMessage, message) && senderIsDifferent(message, prevMessage)) {
+            return ChatMessageAdditionalInfo.SEND_DATE
+        }
+
+        if (!senderIsDifferent(nextMessage, message) && !senderIsDifferent(message, prevMessage)) {
             return ChatMessageAdditionalInfo.EMPTY
         }
 

--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/utils/ChatMessageAdditionalInfoClassifier.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/utils/ChatMessageAdditionalInfoClassifier.kt
@@ -13,14 +13,14 @@ object ChatMessageAdditionalInfoClassifier : IChatMessageAdditionalInfoClassifie
             if (nextMessage != null && senderIsDifferent(message, nextMessage)) {
                 return ChatMessageAdditionalInfo.FULL
             }
-            return ChatMessageAdditionalInfo.SENDER_NAME
+            return ChatMessageAdditionalInfo.SEND_DATE
         }
 
         if (nextMessage == null) {
             if (senderIsDifferent(prevMessage, message)) {
                 return ChatMessageAdditionalInfo.FULL
             }
-            return ChatMessageAdditionalInfo.SEND_DATE
+            return ChatMessageAdditionalInfo.SENDER_NAME
         }
 
         if (
@@ -31,11 +31,11 @@ object ChatMessageAdditionalInfoClassifier : IChatMessageAdditionalInfoClassifie
         }
 
         if (senderIsDifferent(prevMessage, message) && !senderIsDifferent(message, nextMessage)) {
-            return ChatMessageAdditionalInfo.SENDER_NAME
+            return ChatMessageAdditionalInfo.SEND_DATE
         }
 
         if (!senderIsDifferent(prevMessage, message) && senderIsDifferent(message, nextMessage)) {
-            return ChatMessageAdditionalInfo.SEND_DATE
+            return ChatMessageAdditionalInfo.SENDER_NAME
         }
 
         if (!senderIsDifferent(prevMessage, message) && !senderIsDifferent(message, nextMessage)) {


### PR DESCRIPTION
nazwa wysyłającego jest poprawnie wyswietlana na pierwszej wiadomości w serii, a czas wysłania na ostatniej wiadomości w serii.
![image](https://github.com/user-attachments/assets/89fc3f70-d203-485f-95dd-e1c42591d6b6)
