### PR TITLE
[FIX]: Small images remain small in preview

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/components/FullScreenImage.kt
+++ b/composeApp/src/commonMain/kotlin/com/github/familyvault/ui/components/FullScreenImage.kt
@@ -3,10 +3,9 @@ package com.github.familyvault.ui.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
@@ -23,15 +22,15 @@ fun FullScreenImage(
     Dialog(onDismissRequest = onDismiss) {
         Box(
             modifier = Modifier
+                .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.background)
         ) {
             Image(
                 bitmap = imageBitmap,
+                contentScale = ContentScale.FillWidth,
                 contentDescription = stringResource(Res.string.chat_media_full_screen),
                 modifier = Modifier
-                    .wrapContentSize()
-                    .align(Alignment.Center),
-                contentScale = ContentScale.Fit
+                    .fillMaxWidth()
             )
         }
     }


### PR DESCRIPTION
# Description

Issue #180 solution.

Small images are displayed at their original size in the preview. The preview should automatically scale up smaller images to make them more visible, especially for wide images or on certain screen resolutions.